### PR TITLE
Converted Darwin archives to tar.gz

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,8 +49,6 @@ archives:
   format_overrides:
     - goos: windows
       format: zip
-    - goos: darwin
-      format: zip
 - id: ghawrap
   builds:
   - ghawrap
@@ -62,8 +60,6 @@ archives:
     {{- if .Arm }}v{{ .Arm }}{{ end -}}
   format_overrides:
     - goos: windows
-      format: zip
-    - goos: darwin
       format: zip
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
Flip-flopping between archive types is just confusing things.